### PR TITLE
Don't accidentally extend implicit `eval` function

### DIFF
--- a/src/Fuzzy.jl
+++ b/src/Fuzzy.jl
@@ -1,4 +1,10 @@
-module Fuzzy
+baremodule Fuzzy
+
+# We use the name `eval`, which is ordinarily reserved for the implicitly
+# added eval/include functions. To avoid having julia add these names, we
+# use `baremodule` above and add back the Base imports here.
+using Base
+include(args...) = Base.include(Fuzzy, args...)
 
 export TriangularMF, GaussianMF, BellMF, TrapezoidalMF, SigmoidMF
 


### PR DESCRIPTION
This package uses the name `eval`, which is ordinarily reserved for the implicitly provided `eval` function provided by the core system. Adding methods to this generic function worked accidentally due to the way the implementation works, but is probably neither what you want nor guarateed to keep working (e.g. https://github.com/JuliaLang/julia/pull/55949 would break it if merged). To address the issue, make `Fuzzy` a baremodule to avoid implicitly creating the `include`/`eval` names and then add back explicit imports of Base and a definition of `include`.

This way, `Fuzzy.eval` is completely decoupled from the core notion of `eval`.